### PR TITLE
breaking: remove support for eol Python versions

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 isolated_build = true
 envlist =
-    py{3.6,37,38,39,310,311}
+    py{39,310,311,312,313}
     pre-commit
     mypy
 skip_missing_interpreters = true


### PR DESCRIPTION
- adds async support
- replaces requests with httpx
- supports 3.9 through 3.13
